### PR TITLE
Fix most of the broken links

### DIFF
--- a/Publications.html
+++ b/Publications.html
@@ -48,7 +48,7 @@ Proceedings (May 20-24, 1991) Tromso, Norway.
 
 </UL>
 
-<H3><A HREF="http://www.cwi.nl/ftp/mmpapers/">Multimedia</A></H3>
+<H3><A HREF="https://web.archive.org/web/19990225081903/http://www.cwi.nl:80/ftp/mmpapers/">Multimedia</A></H3>
 
 <UL>
 
@@ -96,7 +96,7 @@ Interface.</b>  CWI Report CS-R8817 (April 1988).
 </UL>
 
 <H3><A
-HREF="http://www.cs.vu.nl/vakgroepen/cs/amoeba_papers.html">Amoeba</A></H3>
+HREF="https://web.archive.org/web/20030210053020/http://www.cs.vu.nl/vakgroepen/cs/amoeba_papers.html">Amoeba</A></H3>
 
 <UL>
 

--- a/Resume.html
+++ b/Resume.html
@@ -63,14 +63,14 @@ object-oriented programming language of my own invention.  As an
 elaborate example, I wrote <a href="http://grail.sf.net">Grail</a>,
 the first web browser written in Python.  During this time I also
 wrote a funding proposal, <a
-href="https://web.archive.org/web/20030217160408/http://www.python.org:80/cp4e/">Computer Programming for
+href="https://www.python.org/doc/essays/cp4e/">Computer Programming for
 Everybody</a>, that was funded by DARPA.
 
 <P>From mid October till mid December 1994 I was a guest researcher at
 <A HREF="http://www.nist.gov">NIST</A>, working on <A
 HREF="http://www.python.org">Python</A>.  NIST sponsored my visit to
 the Usenix Symposium on Very High Level Languages in Santa Fe and
-organized the <A HREF="https://web.archive.org/web/20130201175839/http://www.python.org/workshops/">First Python
+organized the <A HREF="http://legacy.python.org/workshops/">First Python
 Workshop</A>.
 
 <H3>Previous Work outside the US</H3>
@@ -78,14 +78,14 @@ Workshop</A>.
 <P>From 1991 till 1995 I worked in the multimedia group at <A
 HREF="http://www.cwi.nl/">CWI</A>, headed by <A
 HREF="http://homepages.cwi.nl/~dcab/">Dick
-Bulterman</A>.  The group is (still) working on authoring software for
+Bulterman</A>.  The group was working on authoring software for
 hypermedia presentations (both implementations and theoretical models)
 and on operating system and network support for multimedia and
 hypermedia, in particular synchronization of independent streams.
-They maintain a <A
+They maintained a <A
 HREF="https://web.archive.org/web/19990225081903/http://www.cwi.nl:80/ftp/mmpapers/">directory</A> containing
 compressed Postscript of publications by the group.  Most of the
-group's implementation work (even after my departure) is done in <A
+group's implementation work (even after my departure) was done in <A
 HREF="http://www.python.org">Python</A>.
 
 <H3>Older Projects</H3>
@@ -96,7 +96,7 @@ HREF="http://www.cwi.nl/">CWI</A>:
 <UL>
 
 <LI>From 1986 till 1991 I was with the Amoeba project, headed by <A
-HREF="http://www.pegasus.esprit.ec.org/~sape/">Sape
+HREF="http://www.diversiorum.org/sape/">Sape
 Mullender</A>.  <A
 HREF="https://web.archive.org/web/20050730074915/http://www.cs.vu.nl/vakgroepen/cs/amoeba_papers.html">Amoeba</A> is a
 distributed operating system developed jointly with the <A
@@ -130,14 +130,14 @@ academic computer center, <A HREF="http://www.sara.nl/">SARA</A>.
 <h3>Awards</h3>
 
 <p>In June 2013 Python won the highly competitive
-<a href="https://web.archive.org/web/20141105123845/http://www.nederlandict.nl/index.shtml?id=12854&ch=ICT">Dutch
+<a href="http://www.commit-nl.nl/news/python-winnaar-commit-award-2013">Dutch
 COMMIT/ Award</a>.
 
 <p>In July 2007 I was awarded the USENIX
 <a href="http://www.usenix.org/about/stug.html">STUG Award</a>.
 
 <p>In October 2006 I was elected
-<a href="https://web.archive.org/web/20061205221308/http://awards.acm.org:80/homepage.cfm?awd=157">ACM
+<a href="https://awards.acm.org/distinguished-members/award-winners?year=2006&award=157&region=North+America&submit=Submit&isSpecialCategory=">ACM
 Distinguished Engineer</a>.
 
 <p>In June 2003 I was finalist in the category "IT - Software
@@ -150,7 +150,7 @@ Award 2003 for extraordinary services to the community of users of
 Unix and Open Systems.
 
 <P>In February 2002 I received the <a
-href="https://web.archive.org/web/20020220040233/http://www.fsf.org:80/press/2002-02-16-FSF-Award.html">Free
+href="https://www.gnu.org/award/2001/2001.html">Free
 Software Foundation Award</a>.
 
 <P>In May 1999 I received the <A

--- a/Resume.html
+++ b/Resume.html
@@ -63,27 +63,27 @@ object-oriented programming language of my own invention.  As an
 elaborate example, I wrote <a href="http://grail.sf.net">Grail</a>,
 the first web browser written in Python.  During this time I also
 wrote a funding proposal, <a
-href="http://www.python.org/cp4e/">Computer Programming for
+href="https://web.archive.org/web/20030217160408/http://www.python.org:80/cp4e/">Computer Programming for
 Everybody</a>, that was funded by DARPA.
 
 <P>From mid October till mid December 1994 I was a guest researcher at
 <A HREF="http://www.nist.gov">NIST</A>, working on <A
 HREF="http://www.python.org">Python</A>.  NIST sponsored my visit to
 the Usenix Symposium on Very High Level Languages in Santa Fe and
-organized the <A HREF="http://www.python.org/workshops/">First Python
+organized the <A HREF="https://web.archive.org/web/20130201175839/http://www.python.org/workshops/">First Python
 Workshop</A>.
 
 <H3>Previous Work outside the US</H3>
 
 <P>From 1991 till 1995 I worked in the multimedia group at <A
 HREF="http://www.cwi.nl/">CWI</A>, headed by <A
-HREF="http://www.cwi.nl/cwi/people/Dick.Bulterman.html">Dick
+HREF="http://homepages.cwi.nl/~dcab/">Dick
 Bulterman</A>.  The group is (still) working on authoring software for
 hypermedia presentations (both implementations and theoretical models)
 and on operating system and network support for multimedia and
 hypermedia, in particular synchronization of independent streams.
 They maintain a <A
-HREF="http://www.cwi.nl/ftp/mmpapers/">directory</A> containing
+HREF="https://web.archive.org/web/19990225081903/http://www.cwi.nl:80/ftp/mmpapers/">directory</A> containing
 compressed Postscript of publications by the group.  Most of the
 group's implementation work (even after my departure) is done in <A
 HREF="http://www.python.org">Python</A>.
@@ -98,18 +98,18 @@ HREF="http://www.cwi.nl/">CWI</A>:
 <LI>From 1986 till 1991 I was with the Amoeba project, headed by <A
 HREF="http://www.pegasus.esprit.ec.org/~sape/">Sape
 Mullender</A>.  <A
-HREF="http://www.cs.vu.nl/vakgroepen/cs/amoeba_papers.html">Amoeba</A> is a
+HREF="https://web.archive.org/web/20050730074915/http://www.cs.vu.nl/vakgroepen/cs/amoeba_papers.html">Amoeba</A> is a
 distributed operating system developed jointly with the <A
-HREF="http://www.cs.vu.nl/vakgroepen/cs/top.html">Computer Systems
+HREF="https://web.archive.org/web/20061006040156/http://www.cs.vu.nl:80/vakgroepen/cs/top.html">Computer Systems
 Group</A> of the <A
-HREF="http://www.cs.vu.nl/vakgroepen/informatica.html">Department of
+HREF="https://web.archive.org/web/20050212074025/http://www.cs.vu.nl/vakgroepen/informatica.html">Department of
 Computer Science</A> of the <A HREF="http://www.vu.nl/">Free
 University of Amsterdam</A>.<P>
 
 <LI>From 1982 till 1986 I was a member of the ABC group, headed by <A
-HREF="http://www.cwi.nl/cwi/people/Lambert.Meertens.html">Lambert
+HREF="http://www.kestrel.edu/home/people/meertens/">Lambert
 Meertens</A> and <A
-HREF="http://www.cwi.nl/cwi/people/Steven.Pemberton.html">Steven
+HREF="http://homepages.cwi.nl/~steven/">Steven
 Pemberton</A>, where my task was the design and implementation of <A
 HREF="http://www.cwi.nl/~steven/abc.html">ABC</A>, a programming
 language and environment for programming by non-expert users.<P>
@@ -130,14 +130,14 @@ academic computer center, <A HREF="http://www.sara.nl/">SARA</A>.
 <h3>Awards</h3>
 
 <p>In June 2013 Python won the highly competitive
-<a href="http://www.nederlandict.nl/index.shtml?id=12854&ch=ICT">Dutch
+<a href="https://web.archive.org/web/20141105123845/http://www.nederlandict.nl/index.shtml?id=12854&ch=ICT">Dutch
 COMMIT/ Award</a>.
 
 <p>In July 2007 I was awarded the USENIX
 <a href="http://www.usenix.org/about/stug.html">STUG Award</a>.
 
 <p>In October 2006 I was elected
-<a href="http://awards.acm.org/homepage.cfm?awd=157">ACM
+<a href="https://web.archive.org/web/20061205221308/http://awards.acm.org:80/homepage.cfm?awd=157">ACM
 Distinguished Engineer</a>.
 
 <p>In June 2003 I was finalist in the category "IT - Software
@@ -150,7 +150,7 @@ Award 2003 for extraordinary services to the community of users of
 Unix and Open Systems.
 
 <P>In February 2002 I received the <a
-href="http://www.fsf.org/press/2002-02-16-FSF-Award.html">Free
+href="https://web.archive.org/web/20020220040233/http://www.fsf.org:80/press/2002-02-16-FSF-Award.html">Free
 Software Foundation Award</a>.
 
 <P>In May 1999 I received the <A

--- a/Resume.html
+++ b/Resume.html
@@ -107,7 +107,7 @@ Computer Science</A> of the <A HREF="http://www.vu.nl/">Free
 University of Amsterdam</A>.<P>
 
 <LI>From 1982 till 1986 I was a member of the ABC group, headed by <A
-HREF="http://www.kestrel.edu/home/people/meertens/">Lambert
+HREF="http://www.cs.uu.nl/staff/lambert.html">Lambert
 Meertens</A> and <A
 HREF="http://homepages.cwi.nl/~steven/">Steven
 Pemberton</A>, where my task was the design and implementation of <A

--- a/interviews.html
+++ b/interviews.html
@@ -28,20 +28,20 @@ vlaag van jeugdige zelfoverschatting"</a> (by Jolein de Rooij, August
 <li><a href="http://www.twit.tv/floss11">FLOSS Weekly 11</a> (by Chris
 DiBona and Leo Laporte, August 4, 2006; <b>audio/podcast</b>)
 
-<li><a href="http://www.tuxjournal.net/intervista2.html">Una serata
+<li><a href="https://web.archive.org/web/20051111012800/http://www.tuxjournal.net:80/intervista2.html">Una serata
 con il Guru del Python</a> (by Vincenzo Ciaglia, translated into
 Italian, May 17, 2005; see also the <a
-href="http://www.tuxjournal.net/intervista2-en.html">English
+href="https://web.archive.org/web/20050601004444/http://www.tuxjournal.net:80/intervista2-en.html">English
 version</a>)
 
 <!-- <li><a href="http://waferbaby.com/corner/guido/">monkey business</a>
 (by Daniel Bogan, April 15, 2005) -->
 
 <li><a
-href="http://www.afpy.org/Members/tarek/afpynews.2005-04-10.2791031007"
+href="https://web.archive.org/web/20051215121014/http://afpy.org:80/Members/tarek/afpynews.2005-04-10.2791031007"
 >AfPy.org</a> (by Tarek Ziadé, translated into French, April 10, 2005;
 English version at <a
-href="http://blogs.nuxeo.com/sections/blogs/tarek_ziade/2005_04_11_guido_van_rossum">his blog</a>)
+href="https://web.archive.org/web/20050430191034/http://blogs.nuxeo.com:80/sections/blogs/tarek_ziade/2005_04_11_guido_van_rossum">his blog</a>)
 
 <li><a
 href="http://www.devsource.com/article2/0,1759,1778141,00.asp"
@@ -58,7 +58,7 @@ href="http://www.onlamp.com/pub/a/python/2003/08/14/gvr_interview.html">ONLamp.c
 (by Xavier Antoviaque, March 2003)
 
 <li><a
-href="http://zweistein.host.sk/hosting/nplejic/scitech/gvr_interview_e.html"
+href="https://web.archive.org/web/20030428002648/http://zweistein.host.sk:80/hosting/nplejic/scitech/gvr_interview_e.html"
 >Zweistein.host.sk</a> (by Nikola Plejic, February 2003; translated
 <a
 href="http://zweistein.host.sk/hosting/nplejic/scitech/gvr_interview.html"
@@ -90,7 +90,7 @@ July 2002):
 </ul>
 
 <li><a
-href="http://codespeak.net/~hpk/news/gvr-interview.html">EuroPython
+href="https://web.archive.org/web/20110723044644/http://codespeak.net/~hpk/news/gvr-interview.html">EuroPython
 2002, published by Codespeak.net</a> translated into German
 (by Holger Krekel, 6/26/02)
 
@@ -111,7 +111,7 @@ href="http://www.xs4all.nl/~johannab/DP-GvR.html">on
 design</a>(Johanna Balusikova, Nov 2001)
 
 <li><a href=
-"http://twistedmatrix.com/users/jh.twistd/python/moin.cgi/GuidoLiveInterview"
+"https://web.archive.org/web/20020721165524/http://www.twistedmatrix.com:80/users/jh.twistd/python/moin.cgi/GuidoLiveInterview"
 >linux.com</a> (moderated live chat on IRC, 7/26/2001)
 
 <li><a
@@ -140,7 +140,7 @@ Journal</a> (by Phil Hughes, 9/28/99, posted 12/1/99)
 Journal</a> (by Phil Hughes, 9/28/99; part 2 of the above)
 
 <li><a
-href="http://www.amk.ca/python/writing/gvr-interview.html">Linux
+href="https://web.archive.org/web/20030803162748/http://www.amk.ca:80/python/writing/gvr-interview.html">Linux
 Journal</a> (by Andrew Kuchling, July 98)
 
 <li><a


### PR DESCRIPTION
Methodology was to use this script: https://gist.github.com/mdamien/7b71ef06f49de1189fb75f8fed91ae82

And then find the proper link by hand (I should automate this part too)

There are a few links in `interviews.html` that I can't find a proper link for:

  - http://www.xs4all.nl/~johannab/DP-GvR.html
  - http://zweistein.host.sk/hosting/nplejic/scitech/gvr_interview.html
  - http://gnu-friends.org/story/2002/2/25/17162/1443

Have a good day :tulip: