### PR TITLE
Fixed missing closing bracket in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@ Offering payment or trips to exotic locales just makes things worse, sorry.
 bug reports (use the <a href="https://github.com/python/cpython/issues">GitHub issue tracker</a>),
 proposals for changes to the language (use <a href="https://discuss.python.org">Discourse</a>),
 job offers (I'm happy where I am),
-or requests to join you in some far-fetched scheme to save humanity (though sometimes I like me a good rant :-).
+or requests to join you in some far-fetched scheme to save humanity (though sometimes I like me a good rant :-)).
 
 <H3>My Name</H3>
 


### PR DESCRIPTION
This pull request addresses a small but important issue in the `index.html` file. A closing parenthesis was missing in a sentence, potentially causing confusion and a slight disruption in the website's content readability. 

**Change Details:**
- File affected: `index.html`
- Section: A sentence discussing "requests to join in far-fetched schemes to save humanity"
- Modification: Added a closing parenthesis at the end of the sentence to complete the text's structure.

The sentence previously read:
"...though sometimes I like me a good rant :-)."

It has been corrected to:
"...though sometimes I like me a good rant :-))."